### PR TITLE
Add a url_only option for attachments that are not images

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,6 @@ You can provide the field with options using `Field::Paperclip.with_options(opti
 
 * `thumbnail_style` (defaults to `'thumbnail'`) to control what image style is used to display the image in collection views
 * `big_style` (defaults to `'original'`) to control what image style is used to display the image on the show page.
+* `url_only` (defaults to `false`) to show only a URL (as a link) instead of trying to display an image.
 
 Based on the [Administrate::Field::Image](https://github.com/thoughtbot/administrate-field-image) template.

--- a/app/views/fields/paperclip/_index.html.erb
+++ b/app/views/fields/paperclip/_index.html.erb
@@ -1,1 +1,5 @@
+<% if field.url_only? -%>
+<%= link_to field.url, field.url if field.url.present? %>
+<% else -%>
 <%= image_tag field.thumbnail %>
+<% end -%>

--- a/app/views/fields/paperclip/_show.html.erb
+++ b/app/views/fields/paperclip/_show.html.erb
@@ -1,1 +1,5 @@
+<% if field.url_only? -%>
+<%= link_to field.url, field.url if field.url.present? %>
+<% else -%>
 <%= image_tag field.url if field.url.present? %>
+<% end -%>

--- a/lib/administrate/field/paperclip.rb
+++ b/lib/administrate/field/paperclip.rb
@@ -16,6 +16,11 @@ module Administrate
       def thumbnail
         style(thumbnail_style)
       end
+      
+      # Just display the URL as a link, rather than trying to make it an image
+      def url_only?
+        options.fetch(:url_only, false)
+      end
 
       alias url style
 

--- a/spec/paperclip_spec.rb
+++ b/spec/paperclip_spec.rb
@@ -61,4 +61,19 @@ RSpec.describe Administrate::Field::Paperclip do
       end
     end
   end
+  
+  describe '#url_only?' do
+    context 'with no options' do
+      it 'should be false' do
+        expect(field.url_only?).to be false
+      end
+    end
+    context 'with url_only option true' do
+      let(:field) { described_class.new(:image, post.image, page, url_only: true) }
+      it 'should be true' do
+        expect(field.url_only?).to be true
+      end
+    end
+  end
+  
 end


### PR DESCRIPTION
Thanks for an amazing gem - I thought I was going to have to make this myself and then yours appeared!

This PR just adds an option to display the URL only, in the case where Paperclip is being used to handle attachments that are not images. Let me know if you need anything else from it!