### PR TITLE
Support all Rails 5 releases

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-#!/usr/bin/env rake
 begin
   require 'bundler/setup'
 rescue LoadError

--- a/administrate-field-paperclip.gemspec
+++ b/administrate-field-paperclip.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split('\n')
 
   gem.add_dependency 'administrate', '~> 0.4'
-  gem.add_dependency 'rails', '>= 4.2', '< 5.1'
+  gem.add_dependency 'rails', '>= 4.2', '< 6'
 
   gem.add_development_dependency 'byebug'
   gem.add_development_dependency 'factory_girl'

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -1,4 +1,7 @@
-class Post < ActiveRecord::Base
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end
+class Post < ApplicationRecord
   include Paperclip::Glue
 
   has_attached_file :image,

--- a/spec/paperclip_spec.rb
+++ b/spec/paperclip_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Administrate::Field::Paperclip do
     end
   end
 
-  PAPECLIP_FIELD_METHODS = %w(style thumbnail url).freeze
+  PAPECLIP_FIELD_METHODS = %w[style thumbnail url].freeze
   PAPECLIP_FIELD_METHODS.each do |method|
     describe "##{method}" do
       context 'when inner_attribute is not set' do


### PR DESCRIPTION
This plugin works fine for Rails 5.1 - here's a PR that relaxes the version constraint to support all of 5.x.