### PR TITLE
Don't attempt to render blank URLs

### DIFF
--- a/app/views/fields/paperclip/_index.html.erb
+++ b/app/views/fields/paperclip/_index.html.erb
@@ -1,4 +1,6 @@
-<% if field.url_only? -%>
+<% if field.blank? -%>
+None
+<% elsif field.url_only? -%>
 <%= link_to field.url, field.url if field.url.present? %>
 <% else -%>
 <%= image_tag field.thumbnail %>

--- a/app/views/fields/paperclip/_show.html.erb
+++ b/app/views/fields/paperclip/_show.html.erb
@@ -1,4 +1,6 @@
-<% if field.url_only? -%>
+<% if field.blank? -%>
+None
+<% elsif field.url_only? -%>
 <%= link_to field.url, field.url if field.url.present? %>
 <% else -%>
 <%= image_tag field.url if field.url.present? %>

--- a/lib/administrate/field/paperclip.rb
+++ b/lib/administrate/field/paperclip.rb
@@ -11,6 +11,10 @@ module Administrate
         data.try(:url, size) || ''
       end
 
+      def blank?
+        data.blank?
+      end
+
       delegate :url, to: :data
 
       def thumbnail


### PR DESCRIPTION
Hi --

Relatively minor pull request, but our admin console was littered with broken image tags for places where the image hadn't been populated yet.

This is a quick and dirty version. Ideally, I'd like to let the user decide what the 'blank field' experience is (perhaps by rendering a user-specified partial), but providing a path to the partial as an option didn't seem right. Wanted to run this past you before I spent too much more time on it.

Thanks!

Ankur
