### PR TITLE
Show only option provided text when field blank

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ You can provide the field with options using `Field::Paperclip.with_options(opti
 * `thumbnail_style` (defaults to `'thumbnail'`) to control what image style is used to display the image in collection views
 * `big_style` (defaults to `'original'`) to control what image style is used to display the image on the show page.
 * `url_only` (defaults to `false`) to show only a URL (as a link) instead of trying to display an image.
+* `blank_text` (defaults to "None") text to show when item is blank.
 
 ## [Contributors](https://github.com/picandocodigo/administrate-field-paperclip/graphs/contributors)
 

--- a/app/views/fields/paperclip/_index.html.erb
+++ b/app/views/fields/paperclip/_index.html.erb
@@ -1,5 +1,7 @@
-<% if field.url_only? -%>
-<%= link_to field.url, field.url if field.url.present? %>
+<% if field.blank? -%>
+  <%= field.blank_text %>
+<% elsif field.url_only? -%>
+  <%= link_to field.url, field.url if field.url.present? %>
 <% else -%>
-<%= image_tag field.thumbnail %>
+  <%= image_tag field.thumbnail %>
 <% end -%>

--- a/app/views/fields/paperclip/_show.html.erb
+++ b/app/views/fields/paperclip/_show.html.erb
@@ -1,5 +1,7 @@
-<% if field.url_only? -%>
-<%= link_to field.url, field.url if field.url.present? %>
+<% if field.blank? -%>
+  <%= field.blank_text %>
+<% elsif field.url_only? -%>
+  <%= link_to field.url, field.url if field.url.present? %>
 <% else -%>
-<%= image_tag field.url if field.url.present? %>
+  <%= image_tag field.url if field.url.present? %>
 <% end -%>

--- a/lib/administrate/field/paperclip.rb
+++ b/lib/administrate/field/paperclip.rb
@@ -7,11 +7,15 @@ module Administrate
       class Engine < ::Rails::Engine
       end
 
+      def blank_text
+        options.fetch(:blank_text, DEFAULT_BLANK_TEXT)
+      end
+
       def style(size = big_style)
         data.try(:url, size) || ''
       end
 
-      delegate :url, to: :data
+      delegate :blank?, :url, to: :data
 
       def thumbnail
         style(thumbnail_style)
@@ -28,6 +32,7 @@ module Administrate
 
       DEFAULT_THUMBNAIL_STYLE = :thumbnail
       DEFAULT_BIG_STYLE = :original
+      DEFAULT_BLANK_TEXT = 'None'.freeze
 
       def thumbnail_style
         options.fetch(:thumbnail_style, DEFAULT_THUMBNAIL_STYLE)

--- a/spec/paperclip_spec.rb
+++ b/spec/paperclip_spec.rb
@@ -5,9 +5,18 @@ RSpec.describe Administrate::Field::Paperclip do
   let(:page) { :show }
   let(:field) { described_class.new(:image, post.image, page) }
   let(:empty_field) { described_class.new(:image, nil, page) }
-
+  let(:empty_text) { 'Empty text' }
+  let(:empty_field_with_blank_option) { described_class.new(:image, nil, page, blank_text: empty_text) }
   require 'administrate/field/paperclip'
 
+  describe '#blank_text' do
+    it 'returns None when blank_text option not set' do
+      expect(empty_field.blank_text).to eq('None')
+    end
+    it 'returns blank text option if set' do
+      expect(empty_field_with_blank_option.blank_text).to eq(empty_text)
+    end
+  end
   describe '#to_partial_path' do
     it 'returns a partial based on the page being rendered' do
       expect(empty_field.to_partial_path).to eq("/fields/paperclip/#{page}")


### PR DESCRIPTION
This is based on [this PR](https://github.com/picandocodigo/administrate-field-paperclip/pull/7)

I added an option to provide the default text and updated the readme accordingly. Also added specs.