### PR TITLE
Use original filename into url only show

### DIFF
--- a/app/views/fields/paperclip/_show.html.erb
+++ b/app/views/fields/paperclip/_show.html.erb
@@ -1,5 +1,5 @@
 <% if field.url_only? -%>
-<%= link_to field.url, field.url if field.url.present? %>
+<%= link_to field.name, field.url if field.url.present? %>
 <% else -%>
 <%= image_tag field.url if field.url.present? %>
 <% end -%>

--- a/app/views/fields/paperclip/_show.html.erb
+++ b/app/views/fields/paperclip/_show.html.erb
@@ -1,5 +1,5 @@
 <% if field.url_only? -%>
-<%= link_to field.name, field.url if field.url.present? %>
+<%= link_to field.resource.send(field.name).original_filename, field.url if field.url.present? %>
 <% else -%>
 <%= image_tag field.url if field.url.present? %>
 <% end -%>


### PR DESCRIPTION
There is more relevant for a url only field show the original filename instead of showing url link